### PR TITLE
fix(link): persist linkcat_id on ve_link update

### DIFF
--- a/dbmodel/schemas/main/common/base/ftrg/gw_trg_edit_link.sql
+++ b/dbmodel/schemas/main/common/base/ftrg/gw_trg_edit_link.sql
@@ -958,7 +958,7 @@ BEGIN
 		enddate = NEW.enddate, uncertain = NEW.uncertain, muni_id = NEW.muni_id, sector_id=v_sector, verified = NEW.verified, custom_length = NEW.custom_length,
 		datasource = NEW.datasource, location_type=NEW.location_type, annotation=NEW.annotation, observ=NEW.observ, comment=NEW.comment,
 		descript=NEW.descript, link=NEW.link, num_value=NEW.num_value, state_type=NEW.state_type, dataquality=NEW.dataquality, dataquality_obs=NEW.dataquality_obs,
-		userdefined_geom = v_userdefined_geom
+		userdefined_geom = v_userdefined_geom, linkcat_id = NEW.linkcat_id
 		WHERE link_id=NEW.link_id;
 
 		IF v_man_table = 'VLINK' THEN

--- a/dbmodel/schemas/main/common/functions/ftrg/gw_trg_edit_link.sql
+++ b/dbmodel/schemas/main/common/functions/ftrg/gw_trg_edit_link.sql
@@ -958,7 +958,7 @@ BEGIN
 		enddate = NEW.enddate, uncertain = NEW.uncertain, muni_id = NEW.muni_id, sector_id=v_sector, verified = NEW.verified, custom_length = NEW.custom_length,
 		datasource = NEW.datasource, location_type=NEW.location_type, annotation=NEW.annotation, observ=NEW.observ, comment=NEW.comment,
 		descript=NEW.descript, link=NEW.link, num_value=NEW.num_value, state_type=NEW.state_type, dataquality=NEW.dataquality, dataquality_obs=NEW.dataquality_obs,
-		userdefined_geom = v_userdefined_geom
+		userdefined_geom = v_userdefined_geom, linkcat_id = NEW.linkcat_id
 		WHERE link_id=NEW.link_id;
 
 		IF v_man_table = 'VLINK' THEN

--- a/dbmodel/schemas/main/common/updates/4/17/0/changelog.txt
+++ b/dbmodel/schemas/main/common/updates/4/17/0/changelog.txt
@@ -1,3 +1,4 @@
+- Persist `linkcat_id` on `ve_link` UPDATE (`gw_trg_edit_link`).
 - Fix `gw_fct_linkexitgenerator` to filter links by sector_id > 0 when is called from `gw_fct_pg2epa_fill_data` function.
 - Improve selector_sector to use sector_id >= 0, now users can select also the 0 sector.
 - Refactor gw_fct_getfeatures with shared list/filter helpers (gw_fct_build_filters_sql, gw_fct_resolve_list_query, gw_fct_build_canvas_filter_sql).

--- a/dbmodel/test/ud/data/test_ve_link.sql
+++ b/dbmodel/test/ud/data/test_ve_link.sql
@@ -11,7 +11,7 @@ SET client_min_messages TO WARNING;
 
 SET search_path = "SCHEMA_NAME", public, pg_catalog;
 
-SELECT plan(11);
+SELECT plan(13);
 
 DELETE FROM link WHERE feature_id = 3095 AND feature_type = 'CONNEC';
 
@@ -26,7 +26,11 @@ JOIN LATERAL (
 	ORDER BY the_geom <-> c.the_geom
 	LIMIT 1
 ) a ON true
-CROSS JOIN LATERAL (SELECT id, link_type FROM cat_link LIMIT 1) cl
+CROSS JOIN LATERAL (
+	SELECT id, link_type FROM cat_link
+	WHERE link_type IN (SELECT link_type FROM cat_link GROUP BY link_type HAVING count(*) > 1)
+	LIMIT 1
+) cl
 WHERE c.connec_id = 3095;
 
 SELECT is((SELECT count(*)::integer FROM ve_link WHERE code = '-901'), 1, 'INSERT: ve_link -901 was inserted');
@@ -49,6 +53,22 @@ SELECT is((SELECT userdefined_geom FROM link WHERE code = '-901'), FALSE, 'UPDAT
 UPDATE ve_link SET verified = 1 WHERE code = '-901';
 SELECT is((SELECT verified::integer FROM ve_link WHERE code = '-901'), 1, 'UPDATE: ve_link -901 was updated');
 SELECT is((SELECT verified::integer FROM link WHERE code = '-901'), 1, 'UPDATE: link -901 was updated');
+
+CREATE TEMP TABLE _linkcat_update AS
+SELECT
+	(SELECT linkcat_id FROM ve_link WHERE code = '-901') AS old_id,
+	(SELECT id FROM cat_link
+	 WHERE link_type = (SELECT link_type FROM ve_link WHERE code = '-901')
+	   AND id IS DISTINCT FROM (SELECT linkcat_id FROM ve_link WHERE code = '-901')
+	 LIMIT 1) AS new_id;
+
+UPDATE ve_link SET linkcat_id = (SELECT new_id FROM _linkcat_update) WHERE code = '-901';
+SELECT is((SELECT linkcat_id FROM ve_link WHERE code = '-901'),
+	(SELECT new_id FROM _linkcat_update),
+	'UPDATE: ve_link linkcat_id was updated');
+SELECT is((SELECT linkcat_id FROM link WHERE code = '-901'),
+	(SELECT new_id FROM _linkcat_update),
+	'UPDATE: link linkcat_id was updated');
 
 DELETE FROM ve_link WHERE code = '-901';
 SELECT is((SELECT count(*)::integer FROM ve_link WHERE code = '-901'), 0, 'DELETE: ve_link -901 was deleted');

--- a/dbmodel/test/ws/data/test_ve_link.sql
+++ b/dbmodel/test/ws/data/test_ve_link.sql
@@ -11,7 +11,7 @@ SET client_min_messages TO WARNING;
 
 SET search_path = "SCHEMA_NAME", public, pg_catalog;
 
-SELECT plan(17);
+SELECT plan(19);
 
 -- Delete existing sample link
 DELETE FROM link WHERE feature_id = 3008 AND feature_type = 'CONNEC';
@@ -39,6 +39,10 @@ SELECT is((SELECT userdefined_geom FROM link WHERE code = '-901'), FALSE, 'UPDAT
 UPDATE ve_link SET verified = 1 WHERE code = '-901';
 SELECT is((SELECT verified::integer FROM ve_link WHERE code = '-901'), 1, 'UPDATE: ve_link -901 was updated');
 SELECT is((SELECT verified::integer FROM link WHERE code = '-901'), 1, 'UPDATE: link -901 was updated');
+
+UPDATE ve_link SET linkcat_id = 'PVC32-PN16' WHERE code = '-901';
+SELECT is((SELECT linkcat_id FROM ve_link WHERE code = '-901'), 'PVC32-PN16', 'UPDATE: ve_link linkcat_id was updated');
+SELECT is((SELECT linkcat_id FROM link WHERE code = '-901'), 'PVC32-PN16', 'UPDATE: link linkcat_id was updated');
 
 
 DELETE FROM ve_link WHERE code = '-901';


### PR DESCRIPTION
## Type

Mark one:

- [x] `fix`
- [ ] `feat`
- [ ] `refactor`
- [ ] `chore`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`
- [ ] `contract`

## Summary

`ve_link` catalog changes from the info form did not persist. `gw_trg_edit_link` wrote `linkcat_id` on INSERT but omitted it from the INSTEAD OF UPDATE, so `gw_fct_setfields` looked successful and the old catalog came back.

- Persist `linkcat_id = NEW.linkcat_id` in `gw_trg_edit_link` UPDATE (`base/` + `functions/` mirror).
- Cover it in ws/ud `test_ve_link` pgTAP.

Reload `gw_trg_edit_link` (or schema update) before checking in QGIS. Catalog must match `link_type` (`PIPELINK` → `PVC32-PN16`, not `UPDATE_LINK_40` / `LINK`).

## Related issue

Closes #

## Scope

What this PR touches:

- [ ] QGIS plugin (Python / UI)
- [x] dbmodel (SQL / patches)
- [ ] i18n
- [ ] CI / workflows
- [ ] docs
- [ ] contracts (JSON schemas / client-facing surfaces)

## Test plan

- [ ] Manual check in QGIS (describe steps if non-obvious)
  - Open a PIPELINK info form, edit, change Linkcat id to another PIPELINK catalog (e.g. `PVC32-PN16`), save, reopen. Value must stick.
  - Same check on UD CONDUITLINK with another catalog of the same `link_type`.
  - Wrong-type catalog (e.g. `UPDATE_LINK_40` on PIPELINK) must still fail message 4464.
- [x] pgTAP / DB tests updated or green (if dbmodel touched)
  - `dbmodel/test/ws/data/test_ve_link.sql` (plan 17 → 19)
  - `dbmodel/test/ud/data/test_ve_link.sql` (plan 11 → 13)
- [ ] Lint / CI green on this PR
- [ ] Screenshots attached (if UI changed)

## Breaking / contract

- [x] N/A
- [ ] Client-facing surface changes (function/view/column shape)

If not N/A, follow the [contract-change issue template](./ISSUE_TEMPLATE/4-contract-change.md) and [dbmodel/MAINTENANCE.md](../dbmodel/MAINTENANCE.md):

- [ ] Linked contract / epic issue
- [ ] Expand/migrate steps documented or done
- [ ] Downgrade / deprecation handled if required