### PR TITLE
fix(elements): GENELEM/FRELEM info actions and Set Geom persist

### DIFF
--- a/core/shared/info.py
+++ b/core/shared/info.py
@@ -379,6 +379,9 @@ class GwInfo(QObject):
                 msg_params = (widget_name,)
                 tools_qgis.show_message(msg, dialog=dialog, msg_params=msg_params)
                 return
+        action.setCheckable(True)
+        action.setChecked(True)
+
         # Block the signals of de dialog so that the key ESC does not close it
         dialog.blockSignals(True)
 
@@ -603,9 +606,11 @@ class GwInfo(QObject):
         dlg_cf, fid = self._manage_actions_signals(complet_result, list_points, new_feature, tab_type, result)
 
         self._show_actions(self.dlg_cf, 'tab_data')
-        if self.new_feature_id is not None and self.feature_type not in ('element'):
+        if self.new_feature_id is not None:
             self._enable_action(self.dlg_cf, "actionCentered", False)
-            self._enable_action(self.dlg_cf, "actionSetToArc", False)
+            # FRELEM keeps Set To Arc (visible from tabactions); GENELEM must not get it
+            if not (self.action_set_to_arc and self.action_set_to_arc.isVisible()):
+                self._enable_action(self.dlg_cf, "actionSetToArc", False)
 
         btn_cancel = self.dlg_cf.findChild(QPushButton, 'btn_cancel')
         btn_accept = self.dlg_cf.findChild(QPushButton, 'btn_accept')
@@ -716,6 +721,8 @@ class GwInfo(QObject):
         self.action_workcat = self.dlg_cf.findChild(QAction, "actionWorkcat")
         self.action_mapzone = self.dlg_cf.findChild(QAction, "actionMapZone")
         self.action_set_to_arc = self.dlg_cf.findChild(QAction, "actionSetToArc")
+        if self.action_set_to_arc:
+            self.action_set_to_arc.setCheckable(True)
         self.action_get_arc_id = self.dlg_cf.findChild(QAction, "actionGetArcId")
         self.action_get_parent_id = self.dlg_cf.findChild(QAction, "actionGetParentId")
         self.action_centered = self.dlg_cf.findChild(QAction, "actionCentered")
@@ -1628,7 +1635,8 @@ class GwInfo(QObject):
         # Therefore whenever the cursor enters a widget, it will ask if we want to save changes
         if not action_edit.isChecked() or from_apply:
             self._get_last_value(dialog, generic)
-            if str(self.my_json) == '{}' and str(self.my_json_epa) == '{}':
+            geom_pending = self.point_xy.get('x') is not None
+            if str(self.my_json) == '{}' and str(self.my_json_epa) == '{}' and not geom_pending:
                 tools_qt.set_action_checked(action_edit, False)
                 tools_gw.enable_widgets(dialog, self.complet_result['body']['data'], False)
                 if self.epa_complet_result:
@@ -1690,7 +1698,8 @@ class GwInfo(QObject):
 
     def _stop_editing(self, dialog, action_edit, layer, fid, my_json, new_feature=None):
 
-        if (my_json == '' or str(my_json) == '{}') and (self.my_json_epa == '' or str(self.my_json_epa) == '{}'):
+        if ((my_json == '' or str(my_json) == '{}') and (self.my_json_epa == '' or str(self.my_json_epa) == '{}')
+                and self.point_xy.get('x') is None):
             QgsProject.instance().blockSignals(True)
             tools_qt.set_action_checked(action_edit, False)
             tools_gw.enable_widgets(dialog, self.complet_result['body']['data'], False)
@@ -1831,6 +1840,8 @@ class GwInfo(QObject):
         newfeature_id = complet_result['body']['feature']['id']
         list_mandatory = []
         skip_mandatory = bool(_json) and set(_json.keys()) == {'epa_type'}
+        if self.point_xy.get('x') is not None and (not _json or str(_json) == '{}'):
+            skip_mandatory = True
         # Manage autoupdate and mandatory widgets
         fields_reload = self._manage_autoupdate_and_mandatory_widgets(dialog, complet_result, p_widget, list_mandatory)
 
@@ -1860,7 +1871,10 @@ class GwInfo(QObject):
                 self.new_feature_id = None
                 self._enable_action(dialog, "actionCentered", True)
                 self._enable_action(dialog, "actionAudit", True)
-                self._enable_action(dialog, "actionSetToArc", True)
+                if self.action_set_to_arc and self.action_set_to_arc.isVisible():
+                    self._enable_action(dialog, "actionSetToArc", True)
+                if self.action_set_geom and self.action_set_geom.isVisible():
+                    self._enable_action(dialog, "actionSetGeom", True)
                 global is_inserting  # noqa: F824
                 is_inserting = False
 
@@ -1924,10 +1938,6 @@ class GwInfo(QObject):
                     self.epa_type = str(new_epa_type_value)
                     self._reload_epa_tab(dialog)
 
-                # Update geometry field (if user have selected a point)
-                if self.point_xy['x'] is not None:
-                    self._update_geom(p_table_id, id_name, newfeature_id)
-
                 if thread:
                     # If param is true show question and create thread
                     msg = "You closed a valve, this will modify the current mapzones and it may take a little bit of time."
@@ -1964,6 +1974,10 @@ class GwInfo(QObject):
             self._reset_my_json_epa()
             if not json_result or "Failed" in json_result['status']:
                 return False
+
+        # Update geometry even when no other fields changed (Set Geom on GENELEM)
+        if self.point_xy.get('x') is not None:
+            self._update_geom(p_table_id, id_name, newfeature_id)
 
         # Force a map refresh
         tools_qgis.refresh_map_canvas()  # First refresh all the layers
@@ -3299,15 +3313,39 @@ class GwInfo(QObject):
         """ Capture point XY from the canvas """
         self.snapper_manager.add_point(self.vertex_marker)
         self.point_xy = self.snapper_manager.point_xy
+        if self.point_xy.get('x') is None or not self.complet_result:
+            return
+        self.complet_result['body']['feature']['geometry'] = {
+            'x': self.point_xy['x'],
+            'y': self.point_xy['y'],
+            'st_astext': f"POINT({self.point_xy['x']} {self.point_xy['y']})"
+        }
+        tools_gw.reset_rubberband(self.rubber_band)
+        tools_gw.draw_by_json(self.complet_result, self.rubber_band)
 
     def _update_geom(self, table_id, id_name, newfeature_id):
         """ Update geometry field """
 
         srid = lib_vars.data_epsg
-        sql = (f"UPDATE {table_id}"
-               f" SET the_geom = ST_SetSRID(ST_MakePoint({self.point_xy['x']},{self.point_xy['y']}), {srid})"
-               f" WHERE {id_name} = {newfeature_id}")
+        sql = (
+            f"UPDATE {table_id}"
+            f" SET the_geom = ST_SetSRID(ST_MakePoint({self.point_xy['x']},{self.point_xy['y']}), {srid})"
+            f" WHERE {id_name}::text = '{newfeature_id}'"
+        )
         tools_db.execute_sql(sql)
+        if self.layer:
+            self.layer.dataProvider().reloadData()
+            self.layer.triggerRepaint()
+        if self.complet_result and self.complet_result.get('body', {}).get('feature') is not None:
+            self.complet_result['body']['feature']['geometry'] = {
+                'x': self.point_xy['x'],
+                'y': self.point_xy['y'],
+                'st_astext': f"POINT({self.point_xy['x']} {self.point_xy['y']})"
+            }
+            tools_gw.reset_rubberband(self.rubber_band)
+            tools_gw.draw_by_json(self.complet_result, self.rubber_band)
+        tools_qgis.force_refresh_map_canvas()
+        self.point_xy = {"x": None, "y": None}
 
     # endregion
 # region Static functions used by the widgets in the custom form
@@ -3714,6 +3752,8 @@ def add_row_epa(tbl, view, tablename, pkey, dlg, dlg_title, force_action, **kwar
 
     # Setup "Set to Arc" action
     action_set_to_arc = info.add_dlg.findChild(QAction, "actionSetToArc")
+    if action_set_to_arc:
+        action_set_to_arc.setCheckable(True)
     tools_gw.add_icon(action_set_to_arc, "157")
 
     action_set_to_arc.triggered.connect(

--- a/core/ui/shared/info_generic.ui
+++ b/core/ui/shared/info_generic.ui
@@ -104,6 +104,9 @@
    </property>
   </action>
   <action name="actionSetToArc">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Set To Arc</string>
    </property>

--- a/core/ui/toolbars/basic/info_feature.ui
+++ b/core/ui/toolbars/basic/info_feature.ui
@@ -730,6 +730,9 @@
    </property>
   </action>
   <action name="actionSetToArc">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Set to arc</string>
    </property>

--- a/dbmodel/schemas/main/common/base/fct/gw_fct_infofromid.sql
+++ b/dbmodel/schemas/main/common/base/fct/gw_fct_infofromid.sql
@@ -433,6 +433,24 @@ BEGIN
 	v_featuretype := LOWER(v_featuretype);
 	v_featuretype := COALESCE(v_featuretype, '');
 
+	-- Parent layers (ve_element, ve_node, ...) match many cat_feature rows. LIMIT 1 above is
+	-- non-deterministic, so GENELEM info was getting FRELEM tabactions (actionSetToArc) and vice versa.
+	-- Re-resolve class/child from the actual feature before building visibleTabs.
+	IF v_id IS NOT NULL AND v_featuretype IN ('node', 'arc', 'connec', 'gully', 'element', 'link') THEN
+		v_querystring = concat(
+			'SELECT lower(cf.feature_class), lower(cf.child_layer) ',
+			'FROM cat_feature cf ',
+			'WHERE cf.id = (SELECT ', v_featuretype, '_type FROM ',
+			quote_ident(COALESCE(v_table_parent, v_tablename)),
+			' WHERE ', v_featuretype, '_id::text = ', quote_literal(v_id), ' LIMIT 1)'
+		);
+		BEGIN
+			EXECUTE v_querystring INTO v_featureclass, v_table_child;
+		EXCEPTION WHEN OTHERS THEN
+			NULL;
+		END;
+	END IF;
+
 	-- Get vdefault values
 	-- Create List
 	list_values = ARRAY['from_date_vdefault','to_date_vdefault','parameter_vdefault','om_param_type_vdefault','edit_doc_type_vdefault'];

--- a/dbmodel/schemas/main/common/functions/fct/gw_fct_infofromid.sql
+++ b/dbmodel/schemas/main/common/functions/fct/gw_fct_infofromid.sql
@@ -438,6 +438,24 @@ BEGIN
 	v_featuretype := LOWER(v_featuretype);
 	v_featuretype := COALESCE(v_featuretype, '');
 
+	-- Parent layers (ve_element, ve_node, ...) match many cat_feature rows. LIMIT 1 above is
+	-- non-deterministic, so GENELEM info was getting FRELEM tabactions (actionSetToArc) and vice versa.
+	-- Re-resolve class/child from the actual feature before building visibleTabs.
+	IF v_id IS NOT NULL AND v_featuretype IN ('node', 'arc', 'connec', 'gully', 'element', 'link') THEN
+		v_querystring = concat(
+			'SELECT lower(cf.feature_class), lower(cf.child_layer) ',
+			'FROM cat_feature cf ',
+			'WHERE cf.id = (SELECT ', v_featuretype, '_type FROM ',
+			quote_ident(COALESCE(v_table_parent, v_tablename)),
+			' WHERE ', v_featuretype, '_id::text = ', quote_literal(v_id), ' LIMIT 1)'
+		);
+		BEGIN
+			EXECUTE v_querystring INTO v_featureclass, v_table_child;
+		EXCEPTION WHEN OTHERS THEN
+			NULL;
+		END;
+	END IF;
+
 	-- Get vdefault values
 	-- Create List
 	list_values = ARRAY['from_date_vdefault','to_date_vdefault','parameter_vdefault','om_param_type_vdefault','edit_doc_type_vdefault'];

--- a/dbmodel/test/ud/function/test_gw_fct_getinfofromid.sql
+++ b/dbmodel/test/ud/function/test_gw_fct_getinfofromid.sql
@@ -11,8 +11,8 @@ SET client_min_messages TO WARNING;
 
 SET search_path = "SCHEMA_NAME", public, pg_catalog;
 
--- Plan for 14 test
-SELECT plan(14);
+-- Plan for 16 test
+SELECT plan(16);
 
 -- Create roles for testing
 CREATE USER plan_user;
@@ -155,6 +155,43 @@ SELECT is(
      WHERE f->>'columnname' = 'sector_id'),
     '',
     've_sector INSERT sector_id value is empty'
+);
+
+-- GENELEM identified from parent ve_element must get Set Geom, not Set To Arc
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM json_array_elements((
+            gw_fct_getinfofromid(format(
+                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
+                (SELECT e.element_id FROM ve_element e
+                 JOIN cat_feature cf ON cf.id = e.element_type
+                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
+            ))::json
+        )->'body'->'form'->'visibleTabs') t
+        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        WHERE t->>'tabName' = 'tab_data'
+          AND a->>'actionName' = 'actionSetGeom'
+    ),
+    'GENELEM info from ve_element parent includes actionSetGeom'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1
+        FROM json_array_elements((
+            gw_fct_getinfofromid(format(
+                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
+                (SELECT e.element_id FROM ve_element e
+                 JOIN cat_feature cf ON cf.id = e.element_type
+                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
+            ))::json
+        )->'body'->'form'->'visibleTabs') t
+        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        WHERE t->>'tabName' = 'tab_data'
+          AND a->>'actionName' = 'actionSetToArc'
+    ),
+    'GENELEM info from ve_element parent does not include actionSetToArc'
 );
 
 -- Finish the test

--- a/dbmodel/test/ud/function/test_gw_fct_getinfofromid.sql
+++ b/dbmodel/test/ud/function/test_gw_fct_getinfofromid.sql
@@ -158,18 +158,34 @@ SELECT is(
 );
 
 -- GENELEM identified from parent ve_element must get Set Geom, not Set To Arc
+CREATE TEMP TABLE _genelem_info ON COMMIT DROP AS
+SELECT gw_fct_getinfofromid(json_build_object(
+    'client', json_build_object('device', 4, 'lang', 'es_ES', 'infoType', 1, 'epsg', 25831),
+    'form', json_build_object(),
+    'feature', json_build_object('tableName', 've_element', 'id', s.gid),
+    'data', json_build_object()
+))::json AS j
+FROM (
+    SELECT e.element_id::text AS gid
+    FROM element e
+    JOIN cat_element ce ON ce.id::text = e.elementcat_id::text
+    JOIN cat_feature cf ON cf.id::text = ce.element_type::text
+    WHERE upper(cf.feature_class) = 'GENELEM'
+    LIMIT 1
+) s;
+
 SELECT ok(
-    EXISTS (
+    EXISTS (SELECT 1 FROM _genelem_info)
+    AND EXISTS (
         SELECT 1
-        FROM json_array_elements((
-            gw_fct_getinfofromid(format(
-                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
-                (SELECT e.element_id FROM ve_element e
-                 JOIN cat_feature cf ON cf.id = e.element_type
-                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
-            ))::json
-        )->'body'->'form'->'visibleTabs') t
-        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        FROM _genelem_info,
+             json_array_elements(
+                 CASE WHEN json_typeof(j->'body'->'form'->'visibleTabs') = 'array'
+                      THEN j->'body'->'form'->'visibleTabs' ELSE '[]'::json END
+             ) t
+        LEFT JOIN LATERAL json_array_elements(
+            CASE WHEN json_typeof(t->'tabactions') = 'array' THEN t->'tabactions' ELSE '[]'::json END
+        ) a ON true
         WHERE t->>'tabName' = 'tab_data'
           AND a->>'actionName' = 'actionSetGeom'
     ),
@@ -177,17 +193,17 @@ SELECT ok(
 );
 
 SELECT ok(
-    NOT EXISTS (
+    EXISTS (SELECT 1 FROM _genelem_info)
+    AND NOT EXISTS (
         SELECT 1
-        FROM json_array_elements((
-            gw_fct_getinfofromid(format(
-                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
-                (SELECT e.element_id FROM ve_element e
-                 JOIN cat_feature cf ON cf.id = e.element_type
-                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
-            ))::json
-        )->'body'->'form'->'visibleTabs') t
-        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        FROM _genelem_info,
+             json_array_elements(
+                 CASE WHEN json_typeof(j->'body'->'form'->'visibleTabs') = 'array'
+                      THEN j->'body'->'form'->'visibleTabs' ELSE '[]'::json END
+             ) t
+        LEFT JOIN LATERAL json_array_elements(
+            CASE WHEN json_typeof(t->'tabactions') = 'array' THEN t->'tabactions' ELSE '[]'::json END
+        ) a ON true
         WHERE t->>'tabName' = 'tab_data'
           AND a->>'actionName' = 'actionSetToArc'
     ),

--- a/dbmodel/test/ws/function/test_gw_fct_getinfofromid.sql
+++ b/dbmodel/test/ws/function/test_gw_fct_getinfofromid.sql
@@ -11,8 +11,8 @@ SET client_min_messages TO WARNING;
 
 SET search_path = "SCHEMA_NAME", public, pg_catalog;
 
--- Plan for 20 test
-SELECT plan(20);
+-- Plan for 22 test
+SELECT plan(22);
 
 -- Create roles for testing
 CREATE USER plan_user;
@@ -202,6 +202,43 @@ SELECT is(
      WHERE f->>'columnname' = 'sector_id'),
     'false',
     've_sector INSERT sector_id is not editable'
+);
+
+-- GENELEM identified from parent ve_element must get Set Geom, not Set To Arc
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM json_array_elements((
+            gw_fct_getinfofromid(format(
+                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
+                (SELECT e.element_id FROM ve_element e
+                 JOIN cat_feature cf ON cf.id = e.element_type
+                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
+            ))::json
+        )->'body'->'form'->'visibleTabs') t
+        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        WHERE t->>'tabName' = 'tab_data'
+          AND a->>'actionName' = 'actionSetGeom'
+    ),
+    'GENELEM info from ve_element parent includes actionSetGeom'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1
+        FROM json_array_elements((
+            gw_fct_getinfofromid(format(
+                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
+                (SELECT e.element_id FROM ve_element e
+                 JOIN cat_feature cf ON cf.id = e.element_type
+                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
+            ))::json
+        )->'body'->'form'->'visibleTabs') t
+        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        WHERE t->>'tabName' = 'tab_data'
+          AND a->>'actionName' = 'actionSetToArc'
+    ),
+    'GENELEM info from ve_element parent does not include actionSetToArc'
 );
 
 -- Finish the test

--- a/dbmodel/test/ws/function/test_gw_fct_getinfofromid.sql
+++ b/dbmodel/test/ws/function/test_gw_fct_getinfofromid.sql
@@ -205,18 +205,34 @@ SELECT is(
 );
 
 -- GENELEM identified from parent ve_element must get Set Geom, not Set To Arc
+CREATE TEMP TABLE _genelem_info ON COMMIT DROP AS
+SELECT gw_fct_getinfofromid(json_build_object(
+    'client', json_build_object('device', 4, 'lang', 'es_ES', 'infoType', 1, 'epsg', 25831),
+    'form', json_build_object(),
+    'feature', json_build_object('tableName', 've_element', 'id', s.gid),
+    'data', json_build_object()
+))::json AS j
+FROM (
+    SELECT e.element_id::text AS gid
+    FROM element e
+    JOIN cat_element ce ON ce.id::text = e.elementcat_id::text
+    JOIN cat_feature cf ON cf.id::text = ce.element_type::text
+    WHERE upper(cf.feature_class) = 'GENELEM'
+    LIMIT 1
+) s;
+
 SELECT ok(
-    EXISTS (
+    EXISTS (SELECT 1 FROM _genelem_info)
+    AND EXISTS (
         SELECT 1
-        FROM json_array_elements((
-            gw_fct_getinfofromid(format(
-                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
-                (SELECT e.element_id FROM ve_element e
-                 JOIN cat_feature cf ON cf.id = e.element_type
-                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
-            ))::json
-        )->'body'->'form'->'visibleTabs') t
-        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        FROM _genelem_info,
+             json_array_elements(
+                 CASE WHEN json_typeof(j->'body'->'form'->'visibleTabs') = 'array'
+                      THEN j->'body'->'form'->'visibleTabs' ELSE '[]'::json END
+             ) t
+        LEFT JOIN LATERAL json_array_elements(
+            CASE WHEN json_typeof(t->'tabactions') = 'array' THEN t->'tabactions' ELSE '[]'::json END
+        ) a ON true
         WHERE t->>'tabName' = 'tab_data'
           AND a->>'actionName' = 'actionSetGeom'
     ),
@@ -224,17 +240,17 @@ SELECT ok(
 );
 
 SELECT ok(
-    NOT EXISTS (
+    EXISTS (SELECT 1 FROM _genelem_info)
+    AND NOT EXISTS (
         SELECT 1
-        FROM json_array_elements((
-            gw_fct_getinfofromid(format(
-                $json${"client":{"device":4,"lang":"es_ES","infoType":1,"epsg":25831},"form":{},"feature":{"tableName":"ve_element","id":"%s"},"data":{}}$json$,
-                (SELECT e.element_id FROM ve_element e
-                 JOIN cat_feature cf ON cf.id = e.element_type
-                 WHERE cf.feature_class = 'GENELEM' LIMIT 1)
-            ))::json
-        )->'body'->'form'->'visibleTabs') t
-        CROSS JOIN LATERAL json_array_elements(COALESCE(t->'tabactions', '[]'::json)) a
+        FROM _genelem_info,
+             json_array_elements(
+                 CASE WHEN json_typeof(j->'body'->'form'->'visibleTabs') = 'array'
+                      THEN j->'body'->'form'->'visibleTabs' ELSE '[]'::json END
+             ) t
+        LEFT JOIN LATERAL json_array_elements(
+            CASE WHEN json_typeof(t->'tabactions') = 'array' THEN t->'tabactions' ELSE '[]'::json END
+        ) a ON true
         WHERE t->>'tabName' = 'tab_data'
           AND a->>'actionName' = 'actionSetToArc'
     ),


### PR DESCRIPTION
## Type

Mark one:

- [x] `fix`
- [ ] `feat`
- [ ] `refactor`
- [ ] `chore`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`
- [ ] `contract`

## Summary

Fix element info actions and Set Geom persistence.

- Identify on parent `ve_element` now resolves `feature_class` from the actual row, so GENELEM (COVER) gets Set Geom and FRELEM (EPUMP/EVALVE) gets Set To Arc
- Set Geom writes even when no other fields changed, then reloads the layer, redraws the rubberband and refreshes the canvas
- Set To Arc is checkable and stays selected while snapping is active

## Related issue



Closes #

## Scope

What this PR touches:

- [x] QGIS plugin (Python / UI)
- [x] dbmodel (SQL / patches)
- [ ] i18n
- [ ] CI / workflows
- [ ] docs
- [ ] contracts (JSON schemas / client-facing surfaces)

## Test plan

- [x] Manual check in QGIS (describe steps if non-obvious)
  - Reload `gw_fct_infofromid` on the live schema, then reload the plugin
  - Identify a COVER on `ve_element`: Set Geom visible, no Set To Arc; pick a point + Accept/Apply → point moves
  - Identify an EPUMP: Set To Arc visible; click it → button stays highlighted until snap/right-click
  - Double-click an element from a feature info Elements tab: Edit still binds to parent `ve_element`; Set Geom updates the map
- [x] pgTAP / DB tests updated or green (if dbmodel touched)
  - `test_gw_fct_getinfofromid` (ws/ud): GENELEM from `ve_element` has `actionSetGeom` and not `actionSetToArc`
- [ ] Lint / CI green on this PR
- [ ] Screenshots attached (if UI changed)



## Breaking / contract

- [x] N/A
- [ ] Client-facing surface changes (function/view/column shape)

If not N/A, follow the [contract-change issue template](./ISSUE_TEMPLATE/4-contract-change.md) and [dbmodel/MAINTENANCE.md](../dbmodel/MAINTENANCE.md):

- [ ] Linked contract / epic issue
- [ ] Expand/migrate steps documented or done
- [ ] Downgrade / deprecation handled if required